### PR TITLE
Rename HTML, PDF manuscript links to dib-lab.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <!-- usage note: edit the H1 title above to personalize the manuscript -->
 
-[![HTML Manuscript](https://img.shields.io/badge/manuscript-HTML-blue.svg)](https://taylorreiter.github.io/2021-paper-metapangenomes/)
-[![PDF Manuscript](https://img.shields.io/badge/manuscript-PDF-blue.svg)](https://taylorreiter.github.io/2021-paper-metapangenomes/manuscript.pdf)
-[![GitHub Actions Status](https://github.com/taylorreiter/2021-paper-metapangenomes/workflows/Manubot/badge.svg)](https://github.com/taylorreiter/2021-paper-metapangenomes/actions)
+[![HTML Manuscript](https://img.shields.io/badge/manuscript-HTML-blue.svg)](https://dib-lab.github.io/2021-paper-metapangenomes/)
+[![PDF Manuscript](https://img.shields.io/badge/manuscript-PDF-blue.svg)](https://dib-lab.github.io/2021-paper-metapangenomes/manuscript.pdf)
+[![GitHub Actions Status](https://github.com/dib-lab/2021-paper-metapangenomes/workflows/Manubot/badge.svg)](https://github.com/dib-lab/2021-paper-metapangenomes/actions)
 
 ## Manuscript description
 
@@ -77,11 +77,11 @@ Whenever a pull request is opened, CI (continuous integration) will test whether
 The build process aims to detect common errors, such as invalid citations.
 If your pull request build fails, see the CI logs for the cause of failure and revise your pull request accordingly.
 
-When a commit to the `main` branch occurs (for example, when a pull request is merged), CI builds the manuscript and writes the results to the [`gh-pages`](https://github.com/taylorreiter/2021-paper-metapangenomes/tree/gh-pages) and [`output`](https://github.com/taylorreiter/2021-paper-metapangenomes/tree/output) branches.
+When a commit to the `main` branch occurs (for example, when a pull request is merged), CI builds the manuscript and writes the results to the [`gh-pages`](https://github.com/dib-lab/2021-paper-metapangenomes/tree/gh-pages) and [`output`](https://github.com/dib-lab/2021-paper-metapangenomes/tree/output) branches.
 The `gh-pages` branch uses [GitHub Pages](https://pages.github.com/) to host the following URLs:
 
-+ **HTML manuscript** at https://taylorreiter.github.io/2021-paper-metapangenomes/
-+ **PDF manuscript** at https://taylorreiter.github.io/2021-paper-metapangenomes/manuscript.pdf
++ **HTML manuscript** at https://dib-lab.github.io/2021-paper-metapangenomes/
++ **PDF manuscript** at https://dib-lab.github.io/2021-paper-metapangenomes/manuscript.pdf
 
 For continuous integration configuration details, see [`.github/workflows/manubot.yaml`](.github/workflows/manubot.yaml).
 
@@ -96,7 +96,7 @@ We encourage users to openly license their manuscripts, which is the default as 
 [![License: CC0 1.0](https://img.shields.io/badge/License%20Parts-CC0%201.0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 Except when noted otherwise, the entirety of this repository is licensed under a CC BY 4.0 License ([`LICENSE.md`](LICENSE.md)), which allows reuse with attribution.
-Please attribute by linking to https://github.com/taylorreiter/2021-paper-metapangenomes.
+Please attribute by linking to https://github.com/dib-lab/2021-paper-metapangenomes.
 
 Since CC BY is not ideal for code and data, certain repository components are also released under the CC0 1.0 public domain dedication ([`LICENSE-CC0.md`](LICENSE-CC0.md)).
 All files matched by the following glob patterns are dual licensed under CC BY 4.0 and CC0 1.0:
@@ -116,4 +116,4 @@ All other files are only available under CC BY 4.0, including:
 + `*.pdf`
 + `*.docx`
 
-Please open [an issue](https://github.com/taylorreiter/2021-paper-metapangenomes/issues) for any question related to licensing.
+Please open [an issue](https://github.com/dib-lab/2021-paper-metapangenomes/issues) for any question related to licensing.


### PR DESCRIPTION
Renames links to HTML and PDF versions of manuscript to dib-lab.github.io domain